### PR TITLE
Fix BoolDefault() to return proper value

### DIFF
--- a/env.go
+++ b/env.go
@@ -124,7 +124,7 @@ func BoolDefault(key string, def bool) bool {
 	sVal := StringDefault(key, strconv.FormatBool(def))
 	val, err := strconv.ParseBool(sVal)
 	if err != nil {
-		return val
+		return def
 	}
-	return def
+	return val
 }


### PR DESCRIPTION
So that it returns the parsed value if there were no errors.
